### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 npm-debug.log
 /src
 /test
+.babelrc


### PR DESCRIPTION
This causes problems when using webpack to compile a project which is dependent on `react-save-refs`. It tries using the `.babelrc` but AFAICT that's not necessary because the source was already transpiled before being published.