### PR TITLE
Update TS typedef to parametrize key type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 type RefFn = (el: object|null) => void;
 
-export default function saveRefs(m: Map<any,object>, key: any): RefFn;
+export default function saveRefs<T>(m: Map<T,object>, key: T): RefFn;


### PR DESCRIPTION
The TypeScript type definition for `saveRefs` imprecisely types the key and map as having `any` types, when it could more precisely be a parametrized type.  This PR changes the type definition to that end.